### PR TITLE
closes #25 既存カプラのプロンテラ転送サービスを無償化

### DIFF
--- a/script/npc/misc/npc_misc_kafra.txt
+++ b/script/npc/misc/npc_misc_kafra.txt
@@ -144,7 +144,8 @@ function	script	KafraMain	{
 		set Zeny,Zeny-'@price['@j];
 		set KAFRA_PIT,KAFRA_PIT+('@price['@j]/10);
 		switch ( getelementofarray(getarg(10),'@j) ) {
-			case 1: warp "prontera.gat",116,72; 	break;
+//			case 1: warp "prontera.gat",116,72; 	break;
+			case 1: warp "prontera.gat",155,195; 	break;
 			case 2: warp "izlude.gat",91,105; 	break;
 			case 3: warp "geffen.gat",120,39; 	break;
 			case 4: warp "payon.gat",160,58; 	break;
@@ -408,7 +409,8 @@ prt_fild05.gat,290,224,4	script	カプラ職員	114,{
 izlude.gat,134,88,4	script	カプラ職員	115,{
 	cutin "kafra_03",2;
 	setarray '@code,1,5,4,3,8;
-	setarray '@price,600,1200,1200,1200,1800;
+//	setarray '@price,600,1200,1200,1200,1800;
+	setarray '@price,0,1200,1200,1200,1800;
 	callfunc "KafraMain",1,0x7f,"prt_fild08.gat",350,202,"izlude.gat",94,103,30,800,'@code,'@price;
 	close2;
 	viewpoint 1,136,88,1,0x0000FF;
@@ -420,10 +422,11 @@ izlude.gat,134,88,4	script	カプラ職員	115,{
 // < ゲフェン - 南噴水 >
 //----------------------------------
 
-geffen.gat,120,62,0	script	カプラ職員	115,{
+geffen.gat,132,66,4	script	カプラ職員	115,{
 	cutin "kafra_03",2;
 	setarray '@code,1,8,7,9;
-	setarray '@price,1200,1200,1700,1700;
+//	setarray '@price,1200,1200,1700,1700;
+	setarray '@price,0,1200,1700,1700;
 	callfunc "KafraMain",0,0x7f,"geffen.gat",120,38,"NULL",0,0,30,800,'@code,'@price;
 	close2;
 	viewpoint 1,120,62,1,0x0000FF;
@@ -439,7 +442,8 @@ geffen.gat,120,62,0	script	カプラ職員	115,{
 geffen.gat,203,123,4	script	カプラ職員	114,{
 	cutin "kafra_04",2;
 	setarray '@code,1,8,7,9;
-	setarray '@price,1200,1200,1700,1700;
+//	setarray '@price,1200,1200,1700,1700;
+	setarray '@price,0,1200,1700,1700;
 	callfunc "KafraMain",0,0x7f,"gef_fild00.gat",55,222,"geffen.gat",120,38,30,800,'@code,'@price;
 	close2;
 	viewpoint 1,120,62,1,0x0000FF;
@@ -455,7 +459,8 @@ geffen.gat,203,123,4	script	カプラ職員	114,{
 morocc.gat,156,97,4	script	カプラ職員	113,{
 	cutin "kafra_05",2;
 	setarray '@code,1,4,6,10,11;
-	setarray '@price,1200,1200,1800,1800,1200;
+//	setarray '@price,1200,1200,1800,1800,1200;
+	setarray '@price,0,1200,1800,1800,1200;
 	callfunc "KafraMain",1,0x7f,"morocc.gat",156,46,"NULL",0,0,40,800,'@code,'@price;
 	close2;
 	viewpoint 1,160,258,1,0x0000FF;
@@ -471,7 +476,8 @@ morocc.gat,156,97,4	script	カプラ職員	113,{
 morocc.gat,160,258,4	script	カプラ職員	114,{
 	cutin "kafra_04",2;
 	setarray '@code,1,4,6,10,11;
-	setarray '@price,1200,1200,1800,1800,1200;
+//	setarray '@price,1200,1200,1800,1800,1200;
+	setarray '@price,0,1200,1800,1800,1200;
 	callfunc "KafraMain",1,0x7f,"moc_fild07.gat",211,29,"morocc.gat",160,283,40,800,'@code,'@price;
 	close2;
 	viewpoint 1,160,258,1,0x0000FF;
@@ -497,7 +503,8 @@ moc_ruins.gat,59,157,6	script	カプラ職員	117,{
 alberta.gat,28,229,0	script	カプラ職員	116,{
 	cutin "kafra_02",2;
 	setarray '@code,4,1,5;
-	setarray '@price,1200,1800,1800;
+//	setarray '@price,1200,1800,1800;
+	setarray '@price,1200,0,1800;
 	callfunc "KafraMain",1,0x7f,"pay_fild03.gat",387,76,"alberta.gat",31,231,50,800,'@code,'@price;
 	close2;
 	viewpoint 1,28,229,1,0x0000FF;
@@ -513,7 +520,8 @@ alberta.gat,28,229,0	script	カプラ職員	116,{
 alberta.gat,113,60,6	script	カプラ職員#alberta2	112,{
 	cutin "kafra_06",2;
 	setarray '@code,4,1,5;
-	setarray '@price,1200,1800,1800;
+//	setarray '@price,1200,1800,1800;
+	setarray '@price,1200,0,1800;
 	callfunc "KafraMain",1,0x7f,"alberta.gat",117,56,"NULL",0,0,50,800,'@code,'@price;
 	close2;
 	viewpoint 1,28,229,1,0x0000FF;
@@ -539,7 +547,8 @@ alb2trea.gat,59,69,6	script	カプラ職員	117,{
 payon.gat,175,226,4	script	カプラ職員	116,{
 	cutin "kafra_02",2;
 	setarray '@code,6,1,5;
-	setarray '@price,1200,1200,1200;
+//	setarray '@price,1200,1200,1200;
+	setarray '@price,1200,0,1200;
 	callfunc "KafraMain",1,0x5f,"payon.gat",207,113,"NULL",0,0,40,800,'@code,'@price;
 	end;
 }
@@ -551,7 +560,8 @@ payon.gat,175,226,4	script	カプラ職員	116,{
 payon.gat,181,104,4	script	カプラ職員	113,{
 	cutin "kafra_05",2;
 	setarray '@code,6,1,5;
-	setarray '@price,1200,1200,1200;
+//	setarray '@price,1200,1200,1200;
+	setarray '@price,1200,0,1200;
 	callfunc "KafraMain",1,0x5f,"payon.gat",160,58,"NULL",0,0,40,800,'@code,'@price;
 	end;
 }
@@ -573,7 +583,8 @@ pay_arche.gat,55,123,4	script	カプラ職員	114,{
 aldebaran.gat,143,119,4	script	カプラ職員	113,{
 	cutin "kafra_05",2;
 	setarray '@code,3,13,2,1,9;
-	setarray '@price,1200,1200,1800,2000,1700;
+//	setarray '@price,1200,1200,1800,2000,1700;
+	setarray '@price,1200,1200,1800,0,1700;
 	callfunc "KafraMain",0,0x5f,"aldebaran.gat",167,112,"NULL",0,0,40,800,'@code,'@price;
 	end;
 }
@@ -584,8 +595,10 @@ aldebaran.gat,143,119,4	script	カプラ職員	113,{
 
 cmd_in02.gat,146,180,4	script	カプラ職員	721,{
 	cutin "kafra_07",2;
-	setarray '@code,5,12;
-	setarray '@price,1800,1200;
+//	setarray '@code,5,12;
+//	setarray '@price,1800,1200;
+	setarray '@code,5,12,1;
+	setarray '@price,1800,1200,0;
 	callfunc "KafraMain",2,0x5f,"comodo.gat",209,143,"NULL",0,0,40,800,'@code,'@price;
 	end;
 }
@@ -596,8 +609,10 @@ cmd_in02.gat,146,180,4	script	カプラ職員	721,{
 
 cmd_fild07.gat,136,134,4	script	カプラ職員	721,{
 	cutin "kafra_07",2;
-	setarray '@code,10,5;
-	setarray '@price,1200,1200;
+//	setarray '@code,10,5;
+//	setarray '@price,1200,1200;
+	setarray '@code,10,5,1;
+	setarray '@price,1200,1200,0;
 	callfunc "KafraMain",2,0x5f,"cmd_fild07.gat",127,134,"NULL",0,0,80,1000,'@code,'@price;
 	end;
 }
@@ -608,8 +623,10 @@ cmd_fild07.gat,136,134,4	script	カプラ職員	721,{
 
 comodo.gat,195,150,4	script	カプラ職員	721,{
 	cutin "kafra_07",2;
-	setarray '@code,5,12,19;
-	setarray '@price,1800,1200,1800;
+//	setarray '@code,5,12,19;
+//	setarray '@price,1800,1200,1800;
+	setarray '@code,5,12,19,1;
+	setarray '@price,1800,1200,1800,0;
 	callfunc "KafraMain",2,0x5f,"comodo.gat",180,151,"NULL",0,0,80,1000,'@code,'@price;
 	end;
 }
@@ -620,9 +637,11 @@ comodo.gat,195,150,4	script	カプラ職員	721,{
 
 gef_fild10.gat,73,340,5	script	カプラ職員	117,{
 	cutin "kafra_01",2;
-	setarray '@code,3,8;
-	setarray '@price,1700,1700;
-	callfunc "KafraMain",0,0x5a,0,0,0,0,0,0,130,800;
+//	setarray '@code,3,8;
+//	setarray '@price,1700,1700;
+	setarray '@code,3,8,1;
+	setarray '@price,1700,1700,0;
+	callfunc "KafraMain",0,0x5a,0,0,0,0,0,0,130,800,'@code,'@price;
 	end;
 }
 
@@ -633,8 +652,9 @@ gef_fild10.gat,73,340,5	script	カプラ職員	117,{
 mjolnir_02.gat,82,362,4	script	カプラ職員	117,{
 	cutin "kafra_01",2;
 	setarray '@code,1,3;
-	setarray '@price,1700,1700;
-	callfunc "KafraMain",1,0x5a,0,0,0,0,0,0,100,800;
+//	setarray '@price,1700,1700;
+	setarray '@price,0,1700;
+	callfunc "KafraMain",1,0x5a,0,0,0,0,0,0,100,800,'@code,'@price;
 	end;
 }
 
@@ -644,8 +664,10 @@ mjolnir_02.gat,82,362,4	script	カプラ職員	117,{
 
 yuno.gat,152,187,4	script	カプラ職員	113,{
 	cutin "kafra_05",2;
-	set '@code,8;
-	set '@price,1200;
+//	set '@code,8;
+//	set '@price,1200;
+	set '@code,8,1;
+	set '@price,1200,0;
 	callfunc "KafraMain",0,0x7f,"yuno.gat",158,124,"NULL",0,0,40,800,'@code,'@price;
 	close2;
 	viewpoint 1,327,109,2,0x0000FF;
@@ -660,8 +682,10 @@ yuno.gat,152,187,4	script	カプラ職員	113,{
 
 yuno.gat,327,109,4	script	カプラ職員	113,{
 	cutin "kafra_05",2;
-	set '@code,8;
-	set '@price,1200;
+//	set '@code,8;
+//	set '@price,1200;
+	set '@code,8,1;
+	set '@price,1200,0;
 	callfunc "KafraMain",0,0x7f,"yuno.gat",327,100,"NULL",0,0,40,800,'@code,'@price;
 	close2;
 	viewpoint 1,152,187,1,0x0000FF;
@@ -676,8 +700,10 @@ yuno.gat,327,109,4	script	カプラ職員	113,{
 
 yuno.gat,277,221,4	script	カプラ職員	113,{
 	cutin "kafra_05",2;
-	set '@code,8;
-	set '@price,1200;
+//	set '@code,8;
+//	set '@price,1200;
+	set '@code,8,1;
+	set '@price,1200,0;
 	callfunc "KafraMain",0,0x7f,"yuno.gat",275,229,"NULL",0,0,40,800,'@code,'@price;
 	close2;
 	viewpoint 1,152,187,1,0x0000FF;
@@ -706,7 +732,10 @@ amatsu.gat,102,149,5	script	カプラ職員#amatsunomal	116,{
 	mes "サービスを欠かしません。";
 	mes "何をお手伝いいたしましょう？";
 	next;
-	callfunc "KafraMain",3,0x5b,"amatsu.gat",116,94,"NULL",0,0,80,700;
+	set '@code,1;
+	set '@price,0;
+//	callfunc "KafraMain",3,0x5b,"amatsu.gat",116,94,"NULL",0,0,80,700;
+	callfunc "KafraMain",3,0x5b,"amatsu.gat",116,94,"NULL",0,0,80,700,'@code,'@price;
 	end;
 }
 
@@ -716,8 +745,12 @@ amatsu.gat,102,149,5	script	カプラ職員#amatsunomal	116,{
 
 gonryun.gat,159,122,4	script	カプラ職員	116,{
 	cutin "kafra_02",2;
-	callfunc "KafraMain",1,0x5b,"gonryun.gat",160,62,"NULL",0,0,80,700;
+	set '@code,1;
+	set '@price,0;
+//	callfunc "KafraMain",1,0x5b,"gonryun.gat",160,62,"NULL",0,0,80,700;
+	callfunc "KafraMain",1,0x5b,"gonryun.gat",160,62,"NULL",0,0,80,700,'@code,'@price;
 	end;
+
 }
 
 //----------------------------------
@@ -726,8 +759,10 @@ gonryun.gat,159,122,4	script	カプラ職員	116,{
 
 umbala.gat,87,160,5	script	カプラ職員	721,{
 	cutin "kafra_07",2;
-	set '@code,10;
-	set '@price,1800;
+//	set '@code,10;
+//	set '@price,1800;
+	set '@code,10,1;
+	set '@price,1800,0;
 	callfunc "KafraMain",0,0x57,"umbala.gat",100,154,"NULL",0,0,80,0,'@code,'@price;
 	end;
 }

--- a/script/original/gon_ama.txt
+++ b/script/original/gon_ama.txt
@@ -1,3 +1,4 @@
+/*
 prontera.gat,152,193,4	script	ŠXˆÚ“®	115,{
 	cutin "kafra_03",2;
 	mes "[ŠXˆÚ“®ƒJƒvƒ‰]";
@@ -15,6 +16,7 @@ prontera.gat,152,193,4	script	ŠXˆÚ“®	115,{
 	cutin "kafra_03",255;
 	end;
 }
+*/
 
 amatsu.gat,102,146,4	script	ŠXˆÚ“®	115,{
 	cutin "kafra_03",2;


### PR DESCRIPTION
主要都市に配置されている、既存カプラのプロンテラへの転送を無償化。