### PR TITLE
closes アイテム消去NPCの設置 #58

### DIFF
--- a/script/original/npc_debug_reset.txt
+++ b/script/original/npc_debug_reset.txt
@@ -2,30 +2,62 @@ prontera.gat,152,183,4	script	リセット職員	117,{
 	cutin "kafra_01",2;
 	mes "[リセット職員]";
 	mes "いらっしゃいませ";
-	mes "こちらではステータス、スキルの";
-	mes "リセットを行えます。";
+	mes "こちらではステータス、スキル、アイテムのリセットを行えます。";
+
 	next;
+
 	mes "[リセット職員]";
-	mes "リセット料金は300Zenyです。";
+	mes "そして・・・ななな、なんと！リセット料金は取らないことにしました！";
+
 	next;
-	set @menu,select("ステータスリセット","スキルリセット","終了");
-	if(@menu < 3) {
-		if(Zeny < 300) {
-			mes "[カプラ職員]";
-			mes "お客様、お金が足りません。";
-			mes "所持金をお確かめください。";
-		}
-		else {
-			set Zeny,Zeny-300;
-			if(@menu == 1)
-				resetstatus;
-			else
-				resetskill;
+
+	mes "[リセット職員]";
+	mes "どうしますか？";
+	switch (select("ステータスリセット","スキルリセット","アイテムリセット","終了"))
+		case 1:
 			mes "[リセット職員]";
-			mes "リセット完了しました。";
-			mes "利用してくださってありがとうございます。";
-		}
+			mes "ステータスをリセットしました！";
+			resetstatus;
+			break;
+
+		case 2:
+			mes "[リセット職員]";
+			mes "スキルをリセットしました！";
+			resetskill;
+			break;
+
+		case 3:
+			mes "[リセット職員]";
+			mes "所持アイテムがすべて削除されます";
+			mes "大切なアイテムはありませんか？消しますよ？";
+			if ( select("ちょっと考えます","消してください") == 2 ){
+				mes "[リセット職員]";
+				mes "大切なものは倉庫にしまってくださいね。";
+				goto L_End;
+			} else {
+				mes "[リセット職員]";
+				mes "3";
+				next;
+				mes "[リセット職員]";
+				mes "2";
+				next;
+				mes "[リセット職員]";
+				mes "1";
+				next;
+				mes "[リセット職員]";
+				mes "アイテム消しちゃいました！";
+				gmcommand '@itemidentify';
+			}
+			break;
+
+		default:
+			goto L_End;
+			break;
 	}
+	mes "[リセット職員]";
+	mes "人生一度きり・・・";
+	mes "気軽にリセットできると思うなよ☆ミ";
+L_End:
 	close2;
 	cutin "kafra_01",255;
 	end;

--- a/script/original/npc_debug_reset.txt
+++ b/script/original/npc_debug_reset.txt
@@ -46,7 +46,7 @@ prontera.gat,152,183,4	script	リセット職員	117,{
 				next;
 				mes "[リセット職員]";
 				mes "アイテム消しちゃいました！";
-				gmcommand '@itemidentify';
+				gmcommand "@itemreset";
 			}
 			break;
 


### PR DESCRIPTION
リセットNPCの選択肢のひとつに、アイテムリセット（所持品全削除）を追加した。
アイテムID指定にしてもよかったけど、それはそれで面倒くさいだろうから実装しなかった。

装備品は削除されないので、装備した後にバグったらキャラデータを直接メンテしないといけない（らしい）

